### PR TITLE
fix: Correct file ignore check for node_modules

### DIFF
--- a/src/eslint-adapter.ts
+++ b/src/eslint-adapter.ts
@@ -146,8 +146,10 @@ export class ESLintAdapter {
   }
 
   public checkFileToBeIgnored(fileName: string) {
-    if (/node_modules[\\/]/.test(fileName)) return;
-    if (!fileName.endsWith(".ts") && !fileName.endsWith(".tsx")) return;
+    if (/node_modules[\\/]/.test(fileName) || (!fileName.endsWith(".ts") && !fileName.endsWith(".tsx"))) {
+      this.ignoredFilepathMap.set(fileName, true);
+      return;
+    }
     Promise.resolve()
       .then(() => new ESLint())
       .then(eslint => eslint.isPathIgnored(fileName))

--- a/src/eslint-adapter.ts
+++ b/src/eslint-adapter.ts
@@ -146,7 +146,7 @@ export class ESLintAdapter {
   }
 
   public checkFileToBeIgnored(fileName: string) {
-    if (fileName.indexOf("node_modules" + path.sep) !== -1) return;
+    if (/node_modules[\\/]/.test(fileName)) return;
     if (!fileName.endsWith(".ts") && !fileName.endsWith(".tsx")) return;
     Promise.resolve()
       .then(() => new ESLint())


### PR DESCRIPTION
Fixes issue where all node_modules and non-ts(x) files are linted even if they're explictly ignored by eslint config.
Also correcting file path check on Windows.

---

#528 fixed most of our problems running on Windows. Unfortunately, it didn't seem to quite fix the code that ignores linting for node_modules.

After some investigation it turns out on Windows, the `checkFileToBeIgnored` method sometimes receives files as standard Windows paths (\\) but sometimes with forward slashes.

This should fix the issue properly. Apologies to @artola for contributing the dodgy fix to your PR 🙂 